### PR TITLE
[AIP-0] §4.6.7, §2.1 — mandate RFC 8785 JCS for action_hash computation (errata #7)

### DIFF
--- a/docs/aip-spec.md
+++ b/docs/aip-spec.md
@@ -324,7 +324,10 @@ Authors' Addresses
 
  This procedure is equivalent to the JSON Canonicalization Scheme
  (JCS) defined in [RFC8785]. Implementations SHOULD use an RFC8785-
- conformant library to ensure correctness.
+ conformant library to ensure correctness. When this procedure is
+ used to compute Action Hashes (Section 4.6.7), implementations
+ MUST use an RFC8785-conformant library; custom serializer
+ implementations MUST NOT be used for that purpose.
 
  EXAMPLE (informative):
 ```
@@ -1365,8 +1368,22 @@ Authors' Addresses
  The `action_hash` MUST be computed as follows:
 
 ```
- action_hash = "sha256:" + HEX( SHA-256( UTF8( canonical_json(action_parameters) ) ) )
+ action_hash = "sha256:" + LCHEX( SHA-256( JCS( action_parameters ) ) )
 ```
+
+ Where:
+
+ - `JCS( x )` denotes serialization of JSON value `x` per the JSON
+   Canonicalization Scheme [RFC8785], producing a UTF-8 byte sequence
+   with no BOM.
+ - `SHA-256( b )` is the SHA-256 hash of byte sequence `b` per
+   [FIPS-180-4].
+ - `LCHEX( h )` is the lowercase hexadecimal encoding of hash `h`
+   using digits `0-9` and `a-f` only.
+ - `"sha256:"` is a literal 7-byte ASCII prefix.
+
+ The resulting `action_hash` value MUST match the pattern
+ `^sha256:[0-9a-f]{64}$`.
 
  Where `action_parameters` is a JSON object containing:
 
@@ -1379,9 +1396,25 @@ Authors' Addresses
  | `action_type` | The `action_type` |
  | `parameters` | A JSON object with all action-specific parameters (e.g., `{"amount": 42.99, "currency": "GBP", "recipient": "amazon.co.uk"}`) |
 
- `canonical_json` MUST produce output per the canonical JSON
- serialization procedure defined in Section 2.1. This is the same
- canonicalization used for signing non-JWT AIP objects.
+ Implementations MUST use an RFC8785-conformant library for JCS
+ serialization (per Section 2.1). The following language-native
+ serializers are NOT RFC8785-conformant and MUST NOT be used
+ directly for this computation: Python `json.dumps`, Go
+ `encoding/json`, Rust `serde_json` (without explicit JCS mode).
+ Using a non-conformant serializer produces silently incorrect
+ hashes that will cause legitimate step claims to fail with
+ `approval_step_action_mismatch` with no diagnostic indication of
+ the root cause.
+
+ NOTE (informative): Recommended RFC8785-conformant libraries:
+ Go: `github.com/cyberphone/json-canonicalization`; Python: `jcs`
+ (PyPI); Rust: `json-canon` crate; JavaScript: `canonicalize`
+ (npm); Java: `json-canonicalization` (Cyberphone).
+
+ Financial amounts and other numeric values in the `parameters`
+ object MUST be represented as JSON numbers (not strings) so that
+ RFC8785 §3.2.2 number canonicalization applies deterministically
+ across implementations.
 
  The `parameters` object is application-defined. It MUST contain all
  values that are material to the action's effect and that the principal


### PR DESCRIPTION
## PR Type

- [ ] Proposal document (new or updated `proposals/XXXX-slug/`)
- [ ] Proposal-to-spec integration (merging an Accepted AIP into `docs/aip-spec.md`)
- [x] Normative spec change (direct edit to `docs/aip-spec.md`)
- [ ] Editorial (`[EDITORIAL]` prefix — no normative impact)
- [ ] JSON Schema change (`schemas/latest/`)
- [ ] Test vector / conformance suite
- [ ] Governance / process document
- [ ] CI / tooling

---

## Summary

Fixes a silent interoperability hazard in Action Hash computation (§4.6.7). Any cross-language deployment using non-RFC8785-conformant JSON serializers (Python `json.dumps`, Go `encoding/json`, Rust `serde_json`) will produce divergent `action_hash` values that cause every step claim to fail with `approval_step_action_mismatch` — with no diagnostic information pointing to the serialization root cause.

Two changes:

1. **§2.1** — adds a normative carve-out: implementations MUST use an RFC8785-conformant library specifically when computing Action Hashes. The existing SHOULD (appropriate for general signature objects over well-controlled internal data) is preserved for all other uses.

2. **§4.6.7** — rewrites the formula using explicit `JCS()`/`SHA-256()`/`LCHEX()` notation with direct [RFC8785] and [FIPS-180-4] citations; lists non-conformant default serializers that MUST NOT be used; adds an informative table of recommended conformant libraries per language; adds a MUST requiring numeric `parameters` values to be JSON numbers (not strings) so IEEE 754 canonicalization applies deterministically.

---

## Linked Issue

Closes #7

---

## Proposal Lifecycle Stage

N/A — errata fix, not a proposal.

---

## Spec Sections Affected

- Section 2.1 — Canonical JSON Serialization
- Section 4.6.7 — Action Hash Computation

---

## Normative-Language Checklist

- [x] All new requirements use RFC 2119 / BCP 14 keywords correctly (MUST / SHOULD / MAY)
- [x] No new requirement conflicts with an existing normative statement
- [x] All new MUST statements reference the relevant AIP error code from `docs/aip-spec.md` Section 13 — `approval_step_action_mismatch` is the relevant code, referenced in the explanatory text
- [ ] If a MUST is added, a corresponding test vector is included — test vectors for cross-language JCS divergence are tracked in issue #7; this PR fixes the normative gap only

---

## Schema Checklist

N/A — no schema files modified.

---

## Security Checklist

- [x] Change reviewed against the AIP threat model — this errata tightens TS-9 (Approval Envelope Manipulation) by closing an implementation gap, not loosening any security property
- [x] DPoP proof-of-possession construction and validation are unaffected
- [x] No algorithm agility holes introduced; prohibited algorithms remain rejected
- [x] Delegation scope rules (D-1 through D-5) are respected and unaffected

---

## Backward Compatibility

- [x] **Non-breaking** — existing valid tokens, registrations, delegation chains, and revocations remain valid under this change

Implementations that were already using an RFC8785-conformant library are unaffected. Implementations using non-conformant serializers were already producing wrong hashes and failing at runtime; this change makes the requirement explicit so they know what to fix.

---

## Spec Consistency

- [x] All internal section cross-references in `docs/aip-spec.md` still resolve after this change
- [x] Table of Contents in `docs/aip-spec.md` is unchanged (no sections added or renamed)
- [x] `AIP_INDEX.md` unaffected (no proposal lifecycle change)
- [x] README.md links are still accurate

---

## DCO Sign-off

- [x] All commits in this PR include `Signed-off-by: Paras Singla <paras.singla@inviscel.com>`